### PR TITLE
Fix codeview

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 selector: "textarea",
                 content_css: 'style.css',
                 menubar: false,
-                toolbar: "bold,italic,mybutton,code,source",
+                toolbar: "bold,italic,mybutton,source",
                 statusbar: false,
 
                 setup : function(ed) {
@@ -42,7 +42,7 @@
                 },
 
                 // variable plugin related
-                plugins: "variables,code,source",
+                plugins: "variables,source",
                 variable_mappers: {
                     username: 'Username',
                     phone: 'Phone',

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 selector: "textarea",
                 content_css: 'style.css',
                 menubar: false,
-                toolbar: "bold,italic,mybutton,code",
+                toolbar: "bold,italic,mybutton,code,source",
                 statusbar: false,
 
                 setup : function(ed) {
@@ -42,7 +42,7 @@
                 },
 
                 // variable plugin related
-                plugins: "variables,code",
+                plugins: "variables,code,source",
                 variable_mappers: {
                     username: 'Username',
                     phone: 'Phone',

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -186,13 +186,12 @@ function htmlToString()
 }
 
 function setCursor(selector) {
-    console.log("setCursor");
-    var ell = editor.dom.select(selector)[0];
+    var ell = currentEditor.dom.select(selector)[0];
     var next = ell.nextSibling;
 
     //this.command('mceFocus',false,this.props.name);
     //editor.selection.setCursorLocation(next);
-    editor.selection.setCursorLocation(next, 1);
+    currentEditor.selection.setCursorLocation(next, 1);
 }
 
 /**
@@ -211,20 +210,20 @@ function editableHandler(e) {
 
         if( keyCode === VK.DELETE || keyCode === VK.BACKSPACE ) {
             // user can delete variable nodes
-            editor.fire('VariableDelete', {value: currentNode.nodeValue});
-            editor.dom.remove( currentNode );
+            currentEditor.fire('VariableDelete', {value: currentNode.nodeValue});
+            currentEditor.dom.remove( currentNode );
         } else if ( keyCode === VK.SPACEBAR || keyCode === VK.RIGHT || keyCode === VK.TOP || keyCode === VK.BOTTOM ) {
             e.preventDefault();
             var variable = currentNode.getAttribute('data-original-variable');
             var t = document.createTextNode(" ");
-            editor.dom.insertAfter(t, currentNode);
+            currentEditor.dom.insertAfter(t, currentNode);
             setCursor('[data-original-variable="' + variable + '"]');
         } else if( keyCode === VK.LEFT ) {
             // move cursor before variable
         } else {
             // user can not modify variables
             e.preventDefault();
-            editor.fire('VariableModifyAttempt', {node: currentNode});
+            currentEditor.fire('VariableModifyAttempt', {node: currentNode});
         }
     }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -232,3 +232,37 @@ tinymce.PluginManager.add('variables', function(editor) {
     editor.on('beforegetcontent', handleContentRerender);
 
 });
+
+tinymce.PluginManager.add('source', function(editor) {
+    editor.addButton('source', {
+        text: 'Edit source',
+        icon: 'code',
+        onclick: function() {
+            var content = editor.getContent();
+
+            // TODO: Remove .variable class
+
+            editor.windowManager.open({
+                title: 'Source code',
+                body: [
+                    {
+                        minHeight: 250,
+                        minWidth: 590,
+                        multiline: true,
+                        name: 'source',
+                        type: 'textbox',
+                        value: content
+                    }
+                ],
+                onsubmit: function(e) {
+                    console.log("[onsubmit]");
+                    editor.setContent(e.data.source); // Insert modified content
+                },
+                onclose: function() {
+                    console.log("[onclose]");
+                    // TODO: Add .variable class
+                }
+            });
+        }
+    });
+});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -185,6 +185,16 @@ function htmlToString()
 
 }
 
+function setCursor(selector) {
+    console.log("setCursor");
+    var ell = editor.dom.select(selector)[0];
+    var next = ell.nextSibling;
+
+    //this.command('mceFocus',false,this.props.name);
+    //editor.selection.setCursorLocation(next);
+    editor.selection.setCursorLocation(next, 1);
+}
+
 /**
  * this function will make sure variable HTML elements can
  * not be edited

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -10,227 +10,20 @@
 
 /*global tinymce:true */
 
+/*------------------------------------*\
+    VARIABLES
+\*------------------------------------*/
+var currentEditor;
+
+/*------------------------------------*\
+    PLUGINS
+\*------------------------------------*/
 tinymce.PluginManager.add('variables', function(editor) {
-
-    var VK = tinymce.util.VK;
-    var stringVariableRegex = new RegExp('{([a-z. _]*)?}', 'g');
-
-    /**
-     * Object that is used to replace the variable string to be used
-     * in the HTML view
-     * @type {object}
-     */
-    var mappers = editor.getParam("variable_mappers", {});
-
-
-    /**
-     * define a list of variables that are allowed
-     * if the variable is not in the list it will not be automatically converterd
-     * by default no validation is done
-     * @todo  make it possible to pass in a function to be used a callback for validation
-     * @type {array}
-     */
-    var valid = editor.getParam("variable_valid", null);
-
-    /**
-     * check if a certain variable is valid
-     * @param {string} name
-     * @return {bool}
-     */
-    function isValid( name )
-    {
-
-        if( ! valid || valid.length === 0 )
-            return true;
-
-        var validString = '|' + valid.join('|') + '|';
-
-        return validString.indexOf( '|' + name + '|' ) > -1 ? true : false;
-    }
-
-    /**
-     * convert a text variable "x" to a span with the needed
-     * attributes to style it with CSS
-     * @param  {string} value
-     * @return {string}
-     */
-    function createHTMLVariable( value ) {
-
-        var cleanValue = value.replace(/[^a-zA-Z._]/g, "");
-
-        // check if variable is valid
-        if( ! isValid(cleanValue) )
-            return value;
-
-        // map value to a more readable value
-        if( mappers.hasOwnProperty(cleanValue) )
-            cleanValue = mappers[cleanValue];
-
-        editor.fire('VariableToHTML', {
-            value: value,
-            cleanValue: cleanValue
-        });
-
-        return '<span class="variable" data-original-variable="' + value + '">' + cleanValue + '</span>';
-    }
-
-    /**
-     * convert variable strings into html elements
-     * @return {void}
-     */
-    function stringToHTML()
-    {
-        var nodeList = [],
-            nodeValue,
-            node,
-            div;
-
-        // find nodes that contain a string variable
-        tinymce.walk(editor.getBody(), function(n) {
-            if (n.nodeType == 3 && n.nodeValue && stringVariableRegex.test(n.nodeValue)) {
-                nodeList.push(n);
-            }
-        }, 'childNodes');
-
-        // loop over all nodes that contain a string variable
-        for (var i = 0; i < nodeList.length; i++) {
-            nodeValue = nodeList[i].nodeValue.replace(stringVariableRegex, createHTMLVariable);
-            div = editor.dom.create('div', null, nodeValue);
-            while ((node = div.lastChild)) {
-                editor.dom.insertAfter(node, nodeList[i]);
-            }
-
-            // remove text variable node
-            // because we now have an HTML representation of the variable
-            editor.dom.remove(nodeList[i]);
-        }
-
-    }
-
-
-    /**
-     * convert HTML variables back into their original string format
-     * for example when a user opens source view
-     * @return {void}
-     */
-    function htmlToString()
-    {
-        var nodeList = [],
-            nodeValue,
-            node,
-            div;
-
-            // find nodes that contain a HTML variable
-        tinymce.walk( editor.getBody(), function(n) {
-            var original = n.parentElement.getAttribute('data-original-variable');
-            if (original !== null) {
-                nodeList.push(n);
-            }
-        }, 'childNodes');
-
-        // loop over all nodes that contain a HTML variable
-        for (var i = 0; i < nodeList.length; i++) {
-            nodeValue = nodeList[i].parentElement.getAttribute('data-original-variable');
-            div = editor.dom.create('div', null, nodeValue);
-            while ((node = div.lastChild)) {
-                editor.dom.insertAfter(node, nodeList[i].parentElement);
-            }
-
-            // remove HTML variable node
-            // because we now have an text representation of the variable
-            editor.dom.remove(nodeList[i].parentElement);
-        }
-
-    }
-
-
-    /**
-     * get variable out of a string
-     * keep in mind that this will only return the first variable even if there are more then one
-     * for example "{hello} test {world}" will return "hello"
-     * @param  {string} value
-     * @return {string}
-     */
-    /*Unused Function
-    function getVariable(value) {
-        var variable, cleanVariable;
-        var variablePickRegex = new RegExp('{([a-z. _]*)?}', 'g');
-        var variableCleanRegex = new RegExp('[^a-zA-Z._]', 'g');
-        var matches = value.match( variablePickRegex );
-        var result = {};
-
-        if( matches.length > 0 ) {
-            for( var i = 0; i < matches.length; i++ ) {
-                variable = matches[i];
-                cleanVariable = variable.replace( variableCleanRegex, '');
-                result[ cleanVariable ] = variable;
-            }
-            return result;
-        }
-
-        return null;
-    }*/
-
-    function setCursor(selector) {
-        var ell = editor.dom.select(selector)[0];
-        var next = ell.nextSibling;
-
-        //this.command('mceFocus',false,this.props.name);
-        //editor.selection.setCursorLocation(next);
-        editor.selection.setCursorLocation(next, 1);
-
-    }
-
-    /**
-     * this function will make sure variable HTML elements can
-     * not be edited
-     * and also make it possible to delete them by hitting backspace
-     * @param  {object} e
-     * @return {void}
-     */
-    function editableHandler(e) {
-
-        var currentNode = tinymce.activeEditor.selection.getNode();
-        var keyCode = e.keyCode;
-
-        if( currentNode.classList.contains('variable') ) {
-
-            if( keyCode === VK.DELETE || keyCode === VK.BACKSPACE ) {
-                // user can delete variable nodes
-                editor.fire('VariableDelete', {value: currentNode.nodeValue});
-                editor.dom.remove( currentNode );
-            } else if ( keyCode === VK.SPACEBAR || keyCode === VK.RIGHT || keyCode === VK.TOP || keyCode === VK.BOTTOM ) {
-                e.preventDefault();
-                var variable = currentNode.getAttribute('data-original-variable');
-                var t = document.createTextNode(" ");
-                editor.dom.insertAfter(t, currentNode);
-                setCursor('[data-original-variable="' + variable + '"]');
-            } else if( keyCode === VK.LEFT ) {
-                // move cursor before variable
-            } else {
-                // user can not modify variables
-                e.preventDefault();
-                editor.fire('VariableModifyAttempt', {node: currentNode});
-            }
-        }
-    }
-
-    /**
-     * handle formatting the content of the editor based on
-     * the current format. For example if a user switches to source view and back
-     * @param  {object} e
-     * @return {void}
-     */
-    function handleContentRerender(e) {
-        return e.format === 'raw' ? stringToHTML() : htmlToString();
-    }
-
-
-    editor.on('nodechange', stringToHTML );
-    editor.on('keyup', stringToHTML );
-    editor.on('keydown', editableHandler );
-    editor.on('beforegetcontent', handleContentRerender);
-
+    // Convert variable strings to HTML when plugin is loaded
+    editor.on('init', function () {
+        currentEditor = editor;
+        stringToHTML();
+    });
 });
 
 tinymce.PluginManager.add('source', function(editor) {
@@ -238,10 +31,13 @@ tinymce.PluginManager.add('source', function(editor) {
         text: 'Edit source',
         icon: 'code',
         onclick: function() {
-            var content = editor.getContent();
+            var content;
 
-            // TODO: Remove .variable class
+            // Convert HTML to strings on 'Source' button click
+            htmlToString();
+            content = editor.getContent();
 
+            // Source dialog settings
             editor.windowManager.open({
                 title: 'Source code',
                 body: [
@@ -255,14 +51,128 @@ tinymce.PluginManager.add('source', function(editor) {
                     }
                 ],
                 onsubmit: function(e) {
-                    console.log("[onsubmit]");
-                    editor.setContent(e.data.source); // Insert modified content
+                    // Insert modified content on submit
+                    editor.setContent(e.data.source);
                 },
                 onclose: function() {
-                    console.log("[onclose]");
-                    // TODO: Add .variable class
+                    // Convert strings to HTML on close/cancel button click
+                    stringToHTML();
                 }
             });
         }
     });
 });
+
+/*------------------------------------*\
+    FUNCTIONS
+\*------------------------------------*/
+/**
+ * convert variable strings into html elements
+ * @return {void}
+ */
+function stringToHTML()
+{
+    var nodeList = [],
+        nodeValue,
+        node,
+        div,
+        stringVariableRegex = new RegExp('{([a-z. _]*)?}', 'g');
+
+    // find nodes that contain a string variable
+    tinymce.walk(currentEditor.getBody(), function(n) {
+        if (n.nodeType == 3 && n.nodeValue && stringVariableRegex.test(n.nodeValue)) {
+            nodeList.push(n);
+        }
+    }, 'childNodes');
+
+    // loop over all nodes that contain a string variable
+    for (var i = 0; i < nodeList.length; i++) {
+        nodeValue = nodeList[i].nodeValue.replace(stringVariableRegex, createHTMLVariable);
+        div = currentEditor.dom.create('div', null, nodeValue);
+        while ((node = div.lastChild)) {
+            currentEditor.dom.insertAfter(node, nodeList[i]);
+        }
+
+        // remove text variable node
+        // because we now have an HTML representation of the variable
+        currentEditor.dom.remove(nodeList[i]);
+    }
+}
+
+/**
+ * check if a certain variable is valid
+ * @param {string} name
+ * @return {bool}
+ */
+function isValid( name )
+{
+    var valid = currentEditor.getParam("variable_valid", null);
+
+    if( ! valid || valid.length === 0 )
+        return true;
+
+    var validString = '|' + valid.join('|') + '|';
+
+    return validString.indexOf( '|' + name + '|' ) > -1 ? true : false;
+}
+
+/**
+ * convert a text variable "x" to a span with the needed
+ * attributes to style it with CSS
+ * @param  {string} value
+ * @return {string}
+ */
+function createHTMLVariable( value ) {
+    var cleanValue = value.replace(/[^a-zA-Z._]/g, "");
+    var mappers = currentEditor.getParam("variable_mappers", {});
+
+    // check if variable is valid
+    if( ! isValid(cleanValue) )
+        return value;
+
+    // map value to a more readable value
+    if( mappers.hasOwnProperty(cleanValue) )
+        cleanValue = mappers[cleanValue];
+
+    currentEditor.fire('VariableToHTML', {
+        value: value,
+        cleanValue: cleanValue
+    });
+
+    return '<span class="variable" data-original-variable="' + value + '">' + cleanValue + '</span>';
+}
+
+/**
+ * convert HTML variables back into their original string format
+ * for example when a user opens source view
+ * @return {void}
+ */
+function htmlToString()
+{
+    var nodeList = [],
+        nodeValue,
+        node,
+        div;
+
+        // find nodes that contain a HTML variable
+    tinymce.walk( currentEditor.getBody(), function(n) {
+        var original = n.parentElement.getAttribute('data-original-variable');
+        if (original !== null) {
+            nodeList.push(n);
+        }
+    }, 'childNodes');
+
+    // loop over all nodes that contain a HTML variable
+    for (var i = 0; i < nodeList.length; i++) {
+        nodeValue = nodeList[i].parentElement.getAttribute('data-original-variable');
+        div = currentEditor.dom.create('div', null, nodeValue);
+        while ((node = div.lastChild)) {
+            currentEditor.dom.insertAfter(node, nodeList[i].parentElement);
+        }
+
+        // remove HTML variable node
+        // because we now have an text representation of the variable
+        currentEditor.dom.remove(nodeList[i].parentElement);
+    }
+
+}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -24,6 +24,14 @@ tinymce.PluginManager.add('variables', function(editor) {
         currentEditor = editor;
         stringToHTML();
     });
+
+    editor.on('keyup', function (e) {
+        stringToHTML();
+    });
+
+    editor.on('keydown', function (e) {
+        editableHandler(e);
+    });
 });
 
 tinymce.PluginManager.add('source', function(editor) {
@@ -175,4 +183,38 @@ function htmlToString()
         currentEditor.dom.remove(nodeList[i].parentElement);
     }
 
+}
+
+/**
+ * this function will make sure variable HTML elements can
+ * not be edited
+ * and also make it possible to delete them by hitting backspace
+ * @param  {object} e
+ * @return {void}
+ */
+function editableHandler(e) {
+    var VK = tinymce.util.VK;
+    var currentNode = tinymce.activeEditor.selection.getNode();
+    var keyCode = e.keyCode;
+
+    if( currentNode.classList.contains('variable') ) {
+
+        if( keyCode === VK.DELETE || keyCode === VK.BACKSPACE ) {
+            // user can delete variable nodes
+            editor.fire('VariableDelete', {value: currentNode.nodeValue});
+            editor.dom.remove( currentNode );
+        } else if ( keyCode === VK.SPACEBAR || keyCode === VK.RIGHT || keyCode === VK.TOP || keyCode === VK.BOTTOM ) {
+            e.preventDefault();
+            var variable = currentNode.getAttribute('data-original-variable');
+            var t = document.createTextNode(" ");
+            editor.dom.insertAfter(t, currentNode);
+            setCursor('[data-original-variable="' + variable + '"]');
+        } else if( keyCode === VK.LEFT ) {
+            // move cursor before variable
+        } else {
+            // user can not modify variables
+            e.preventDefault();
+            editor.fire('VariableModifyAttempt', {node: currentNode});
+        }
+    }
 }


### PR DESCRIPTION
This bug was caused because the `nodechange` event did not always fire when closing the dialog outside the editor.

I've changed the codeview to a custom plugin so we can add `onclick`, `onclose` and other handlers, which seemed a lot cleaner to me. So now the `stringToHTML` always gets executed when the dialog is closed.

resolve #2 
