### PR TITLE
Reset tinyMce content to html after getContent called. Reset cursor after getContent called. Fix Regex.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -42,7 +42,15 @@ tinymce.PluginManager.add('variable', function(editor) {
      */
     var prefix = editor.getParam("variable_prefix", "{{");
     var suffix = editor.getParam("variable_suffix", "}}");
-    var stringVariableRegex = new RegExp(prefix + '([a-z. _]*)?' + suffix, 'g');
+
+    /**
+     * RegExp is not stateless with '\g' so we return a new variable each call
+     * @return {RegExp}
+     */
+    function getStringVariableRegex()
+    {
+        return new RegExp(prefix + "[a-zA-Z. _]+" + suffix, "g");
+    }
 
     /**
      * check if a certain variable is valid
@@ -115,14 +123,14 @@ tinymce.PluginManager.add('variable', function(editor) {
 
         // find nodes that contain a string variable
         tinymce.walk(editor.getBody(), function(n) {
-            if (n.nodeType == 3 && n.nodeValue && stringVariableRegex.test(n.nodeValue)) {
+            if (n.nodeType == 3 && n.nodeValue && getStringVariableRegex().test(n.nodeValue)) {
                 nodeList.push(n);
             }
         }, 'childNodes');
 
         // loop over all nodes that contain a string variable
         for (var i = 0; i < nodeList.length; i++) {
-            nodeValue = nodeList[i].nodeValue.replace(stringVariableRegex, createHTMLVariable);
+            nodeValue = nodeList[i].nodeValue.replace(getStringVariableRegex(), createHTMLVariable);
             div = editor.dom.create('div', null, nodeValue);
             while ((node = div.lastChild)) {
                 editor.dom.insertAfter(node, nodeList[i]);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -129,7 +129,6 @@ tinymce.PluginManager.add('variable', function(editor) {
 
                 if(isVariable(node)) {
                     var next = node.nextSibling;
-                    editor.selection.setCursorLocation(next);
                 }
             }
 
@@ -174,14 +173,6 @@ tinymce.PluginManager.add('variable', function(editor) {
 
     }
 
-    function setCursor(selector) {
-        var ell = editor.dom.select(selector)[0];
-        if(ell) {
-            var next = ell.nextSibling;
-            editor.selection.setCursorLocation(next);
-        }
-    }
-
     /**
      * handle formatting the content of the editor based on
      * the current format. For example if a user switches to source view and back
@@ -190,8 +181,12 @@ tinymce.PluginManager.add('variable', function(editor) {
      */
     function handleContentRerender(e) {
         // store cursor location
+        var cursorBookmark = tinymce.activeEditor.selection.getBookmark(1, true);
+
         return e.format === 'raw' ? stringToHTML() : htmlToString();
+
         // restore cursor location
+        tinymce.activeEditor.selection.moveToBookmark(cursorBookmark);
     }
 
     /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -228,9 +228,8 @@ tinymce.PluginManager.add('variable', function(editor) {
         });
     }
 
-    editor.on('nodechange', stringToHTML );
-    editor.on('keyup', stringToHTML );
     editor.on('beforegetcontent', handleContentRerender);
+    editor.on('getcontent', stringToHTML );
     editor.on('click', handleClick);
 
     this.addVariable = addVariable;


### PR DESCRIPTION
Reset tinyMce content to html after getContent called:
Users should be able to call getContent without the tinyMCE content changing.

Reset cursor after getContent called:
When getContent was called the current location of the cursor was not reset after the function.

Fix Regex:
RegExp is [not stateless in JS](https://stackoverflow.com/a/13233782) and when multiple variables are added next to each other without a separator and could cause an issue when parsing.

Please let me know if you have any questions or concerns.
Cam