### PR TITLE
Prevent cleanVariable from editing the variable itself

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,7 +74,7 @@ tinymce.PluginManager.add('variable', function(editor) {
      * @return {string}
      */
     function cleanVariable(value) {
-        return value.replace(/[^a-zA-Z0-9._]/g, "");
+        return value.substring(prefix.length, value.length - suffix.length);
     }
 
     /**


### PR DESCRIPTION
This makes it so that cleanVariable just cuts off the prefix and suffix and actually leaves the variable itself alone. Good for variables that happen to contain characters that the old regex didn't like.